### PR TITLE
Fallback to `os.homedir()` on Windows

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,10 +1,11 @@
 passwdUser = require 'passwd-user'
+homedir = require 'os-homedir'
 Promise = require 'bluebird'
 
 module.exports = (username, cb) ->
 	Promise.try ->
 		if process.platform isnt 'linux' and process.platform isnt 'darwin'
-			throw new Error('Platform not supported.')
+			return homedir()
 
 		username = username ? process.env.SUDO_USER or process.env.USER
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Platform-agnostic user home directory for any user.",
   "dependencies": {
     "bluebird": "^3.3.4",
+    "os-homedir": "^1.0.1",
     "passwd-user": "~2.0.0"
   }
 }


### PR DESCRIPTION
The home directory will always be the correct one on Windows on
elevation, so we fallback to the default way of getting the home
directory in this case.

We could have used `os.homedir()`, which was added in NodeJS v4, however
we use a shim. `os-homedir` to cover older versions as well.

See https://github.com/sindresorhus/os-homedir
Signed-off-by: Juan Cruz Viotti jviottidc@gmail.com
